### PR TITLE
chore: bump desktop app version and fix ESLint configuration

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typelets-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Typelets Desktop - Secure Note Taking App",
   "main": "dist/main.js",
   "author": "Typelets Team",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default tseslint.config(
   {
     ignores: [
       'dist',
+      'apps/desktop/dist',
       'node_modules',
       '.vite',
       'coverage',


### PR DESCRIPTION
## Summary
  - Bump desktop app version from 0.1.0 to 0.1.1 to trigger GitHub Actions release
  - Fix ESLint configuration to exclude desktop dist directory from linting

  ## Changes
  - **Version bump**: Update `apps/desktop/package.json` version to 0.1.1
  - **ESLint fix**: Add `apps/desktop/dist` to ignored directories in eslint.config.js

  ## Technical Details
  - The version bump will trigger the GitHub Actions workflow to create a public release with downloadable executables
  - The ESLint fix prevents linting errors on compiled JavaScript files in the desktop dist directory
  - This resolves pre-push hook failures when trying to push desktop app changes

  ## Test Plan
  - [x] ESLint passes without errors
  - [x] Version change detected for release workflow
  - [ ] GitHub Actions creates release with Windows/Mac/Linux executables
